### PR TITLE
clarify proposal and conclusion

### DIFF
--- a/text/0002-extracting-necko.md
+++ b/text/0002-extracting-necko.md
@@ -1,6 +1,6 @@
-# Problem
+# Proposal
 
-Can we break out a Gecko component, such as Necko, for reuse in background services and on mobile platforms?
+We should extract Necko for reuse in background services and on mobile platforms.
 
 ## Motivation
 
@@ -34,7 +34,7 @@ Breaking out a component for reuse is, for our purposes, equivalent to embedding
 * Parts of Necko are still single-threaded, requiring new channels to be created on the main thread, and dispatching callbacks to the main thread.
 * Necko's init and deinit are managed by observer notifications, which is not ideal for embedding outside of Gecko.
 
-# Proposal
+# Conclusion
 
 Necko is a very feature-rich C++ networking library that is directly targeted at meeting the needs of single-user, single-main-process, single-profile, interactive applications built on a persistent profile directory in the traditional Mozilla model. It is not well-suited for use outside of the Gecko lifecycle — indeed, almost every aspect is designed for the Gecko world — and would require substantial effort in decoupling to be suited for embedded use. Even if so decoupled, it would still mandate the use of XPCOM and the NSPR.
 


### PR DESCRIPTION
Per [my recent comment in a thread on the original pull request](https://github.com/mozilla/firefox-browser-architecture/pull/2#discussion_r134298508), I think we should revisit the titles of the Problem and Proposal sections, and the structure of the text in the Problem section, in this document. Specifically:
* rename Problem section to Proposal
* change "problem statement" from question to assertion
* rename Proposal section to Conclusion