### PR TITLE
Brief should identify review that has already happened.

### DIFF
--- a/text/0006-architecture-review-process.md
+++ b/text/0006-architecture-review-process.md
@@ -38,6 +38,7 @@ The Review Packet includes:
     - the architecture being proposed
     - scenarios that exercise the requirements/goals against the proposed architecture
     - how the proposal handles these scenarios
+    - what review and discussion of the proposed architecture has already happened (and with whom)
   * A competitive analysis suggesting alternatives, costs, and opportunities
 
 3. The chair creates a list of questions to be discussed during the review. These questions should be:


### PR DESCRIPTION
I think this is helpful for identifying gaps.  For example, if the team notes that they've talked to two other teams about their design, that might prompt some of the reviewers (or the team itself, as they write the brief) to notice that there's a third team that they also need to talk to.