### PR TITLE
Remove `--unified-headers` flag from Rust On Android article.

### DIFF
--- a/experiments/2017-09-21-rust-on-android.md
+++ b/experiments/2017-09-21-rust-on-android.md
@@ -40,9 +40,9 @@ Now let's create our standalone NDKs. There is no need to be inside the `NDK` di
 
 ```
 mkdir NDK
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 21 --arch arm64 --install-dir NDK/arm64
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 14 --arch arm --install-dir NDK/arm
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 14 --arch x86 --install-dir NDK/x86
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 26 --arch arm64 --install-dir NDK/arm64
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 26 --arch arm --install-dir NDK/arm
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 26 --arch x86 --install-dir NDK/x86
 ```
 
 Create a new file, `cargo-config.toml`. This file will tell cargo where to look for the NDKs during cross compilation. Add the following content to the file, remembering to replace instances of `<project path>` with the path to your project directory.

--- a/experiments/2017-09-21-rust-on-android.md
+++ b/experiments/2017-09-21-rust-on-android.md
@@ -40,9 +40,9 @@ Now let's create our standalone NDKs. There is no need to be inside the `NDK` di
 
 ```
 mkdir NDK
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --unified-headers --api 21 --arch arm64 --install-dir NDK/arm64
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --unified-headers --api 14 --arch arm --install-dir NDK/arm
-${NDK_HOME}/build/tools/make_standalone_toolchain.py --unified-headers --api 14 --arch x86 --install-dir NDK/x86
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 21 --arch arm64 --install-dir NDK/arm64
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 14 --arch arm --install-dir NDK/arm
+${NDK_HOME}/build/tools/make_standalone_toolchain.py --api 14 --arch x86 --install-dir NDK/x86
 ```
 
 Create a new file, `cargo-config.toml`. This file will tell cargo where to look for the NDKs during cross compilation. Add the following content to the file, remembering to replace instances of `<project path>` with the path to your project directory.


### PR DESCRIPTION
As reported in https://github.com/fluffyemily/cross-platform-rust/issues/33 the unified headers flag is now default on the `make_standalong_toolchain.py` script for Android sdk cross compilation. The flag is now removed from the article in order to keep the information relevant and useful.