### PR TITLE
Update the README to include the text from the Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,9 +7,4 @@ For more details, please read the
 ## How to Report
 For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
 
-<!--
-## Project Specific Etiquette
-
-In some cases, there will be additional project etiquette i.e.: (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
-Please update for your project.
--->
+<!-- There is copy of this text in README.md -->

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ To support our conclusions we occasionally perform explorations and experiments.
 
 * [Deploying a Rust library on iOS](experiments/2017-09-06-rust-on-ios.md). A short tutorial describing how to build and deploy a Rust library for use inside an iOS app.
 * [Deploying a Rust library on Android](experiments/2017-09-21-rust-on-android.md). A short tutorial describing how to build and deploy a Rust library for use inside an Android app.
+
+<!-- This is a copy of this text in CODE_OF_CONDUCT.md -->
+
+# Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+
+## How to Report
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.


### PR DESCRIPTION
Rather than using a link to the Code of Conduct, I just included it verbatim as it's short.

This solution isn't DRY, but forcing users to visit a link for a couple of sentences which are themselves just a link, didn't seem very friendly.
